### PR TITLE
fix: vite api calls

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,9 +4,6 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vite.dev/config/
 export default defineConfig({
-  server: {
-    historyApiFallback: true,
-  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
This pull request removes the `server` configuration from the `vite.config.ts` file. The `historyApiFallback` option, which was previously set to `true`, has been deleted. This change simplifies the configuration and may indicate that fallback handling is no longer required or is being managed elsewhere.

* [`frontend/vite.config.ts`](diffhunk://#diff-97c6e2c429ec483132c584137a18a1ade2ff6c3f4f6485f4a83db604d0323d7cL7-L9): Removed the `server` configuration block, including the `historyApiFallback: true` setting.